### PR TITLE
Refactor styles, add variable to adjust heading color

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Published on webcomponents.org](https://img.shields.io/badge/webcomponents.org-published-blue.svg)](https://www.webcomponents.org/element/advanced-rest-client/api-parameters-document)
 
-## api-parameters-document
+## &lt;api-parameters-document&gt;
 
 Documentation component for API query and URI parameters based on AMF data model.
 
@@ -13,11 +13,26 @@ Documentation component for API query and URI parameters based on AMF data model
 This version only works with AMF model version 2 (AMF parser >= 4.0.0).
 For compatibility with previous model version use `3.x.x` version of the component.
 
+## Styling
+
+`<api-parameters-document>` provides the following custom properties and mixins for styling:
+
+Custom property | Description | Default
+----------------|-------------|----------
+`--arc-font-subhead-color` | Color of the collapsible section title | ``
+`--arc-font-subhead-font-size` | Font size of the collapsible section title | ``
+`--arc-font-subhead-line-height` | Line height of the collapsible section title | ``
+`--arc-font-subhead-narrow-font-size` | Font size of the collapsible section title in mobile-friendly view | ``
+`--arc-font-body1-font-size` |  | ``
+`--arc-font-body1-font-weight` |  | ``
+`--arc-font-body1-line-height` |  | ``
+`--api-parameters-document-title-border-color` | Border color of the collapsible section title area | `#e5e5e5`
+
 ## Usage
 
 ### Installation
 
-```
+```sh
 npm install --save @api-components/api-parameters-document
 ```
 
@@ -72,4 +87,4 @@ npm test
 
 ## API components
 
-This components is a part of [API components ecosystem](https://elements.advancedrestclient.com/)
+This component is a part of [API components ecosystem](https://elements.advancedrestclient.com/)

--- a/src/ApiParametersDocument.js
+++ b/src/ApiParametersDocument.js
@@ -10,12 +10,12 @@ import '@anypoint-web-components/anypoint-button/anypoint-button.js';
  * URI and query parameters documentation table based on
  * [AMF](https://github.com/mulesoft/amf) json/ld model.
  *
- * It rquires you to set at least one of the following properties:
+ * One of the following properties must be set:
  * - baseUriParameters
  * - endpointParameters
  * - queryParameters
  *
- * Otherwise it render empty block element.
+ * Otherwise it renders an empty block element.
  *
  * See demo for example implementation.
  *

--- a/src/ApiParametersDocument.js
+++ b/src/ApiParametersDocument.js
@@ -40,22 +40,14 @@ export class ApiParametersDocument extends LitElement {
       display: flex;
       flex-direction: row;
       align-items: center;
-      cursor: pointer;
-      -webkit-user-select: none;
-      -moz-user-select: none;
-      -ms-user-select: none;
-      user-select: none;
       border-bottom: 1px var(--api-parameters-document-title-border-color, #e5e5e5) solid;
+      cursor: pointer;
+      user-select: none;
       transition: border-bottom-color 0.15s ease-in-out;
     }
-
+    
     .section-title-area[opened] {
       border-bottom-color: transparent;
-    }
-
-    .section-title-area .table-title {
-      flex: 1;
-      flex-basis: 0.000000001px;
     }
 
     .toggle-icon {
@@ -69,17 +61,16 @@ export class ApiParametersDocument extends LitElement {
       transform: rotateZ(-180deg);
     }
 
-    .table-title {
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
+    .heading3 {
+      flex: 1;
+      color: var(--arc-font-subhead-color);
       font-size: var(--arc-font-subhead-font-size);
       font-weight: var(--arc-font-subhead-font-weight);
       line-height: var(--arc-font-subhead-line-height);
     }
-
-    :host([narrow]) .table-title {
-      font-size: var(--api-parameters-document-title-narrow-font-size, initial);
+    
+    :host([narrow]) .heading3 {
+      font-size: var(--arc-font-subhead-narrow-font-size, 17px);
     }
 
     .icon {
@@ -117,7 +108,7 @@ export class ApiParametersDocument extends LitElement {
         title="Toogle URI parameters details"
         ?opened="${pathOpened}"
       >
-        <div class="table-title" role="heading" aria-level="${headerLevel}">URI parameters</div>
+        <div class="heading3 table-title" role="heading" aria-level="${headerLevel}">URI parameters</div>
         <div class="title-area-actions">
           <anypoint-button class="toggle-button" ?compatibility="${compatibility}">
             ${this._computeToggleActionLabel(pathOpened)}
@@ -144,7 +135,7 @@ export class ApiParametersDocument extends LitElement {
         title="Toogle query parameters details"
         ?opened="${queryOpened}"
       >
-        <div class="table-title" role="heading" aria-level="${headerLevel}">Query parameters</div>
+        <div class="heading3 table-title" role="heading" aria-level="${headerLevel}">Query parameters</div>
         <div class="title-area-actions">
           <anypoint-button class="toggle-button" ?compatibility="${compatibility}">
             ${this._computeToggleActionLabel(queryOpened)}


### PR DESCRIPTION
1. Fix typos in the `ApiParametersDocument` class description.
2. Replace the `.table-title` class with `.heading3` like it's done in other sections (see also https://github.com/advanced-rest-client/api-body-document/pull/19)
3. Add `--arc-font-subhead-color` to allow heading color modification.